### PR TITLE
fix(require-props-suffix): Check if typeName exist

### DIFF
--- a/src/rules/require-props-suffix.ts
+++ b/src/rules/require-props-suffix.ts
@@ -43,7 +43,8 @@ export default util.createRule({
         if (
           node.left.name === "React" &&
           node.right.name === "FC" &&
-          node.parent.typeParameters
+          node.parent.typeParameters &&
+          node.parent.typeParameters.params[0].typeName
         ) {
           if (node.parent.typeParameters.params.length === 0) {
             return reportError(node);


### PR DESCRIPTION
If a type is "anonymous", i.e. written directly as an object, there isn't a typeName and this crashes. Check if there is a name first.